### PR TITLE
Update Python version from 3.9 to 3.10 in Dockerfile for consistency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.10
 
 WORKDIR /app
 


### PR DESCRIPTION
This pull request includes an update to the `Dockerfile` to use a newer version of Python.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R1): Updated the base image from `python:3.9` to `python:3.10` to ensure compatibility with the latest features and improvements in Python.