### PR TITLE
Add Docker compose for backend+frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,8 @@ log/
 
 # Local development settings
 .local/
+
+# Node
+node_modules/
+frontend/node_modules/
+frontend/.next/

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,6 @@ COPY requirements.txt .
 # Install dependencies using pip (simplifying to avoid credential issues)
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Install uv package manager
-RUN pip install --no-cache-dir uv
 
 # Copy the rest of the application
 COPY . .

--- a/README.md
+++ b/README.md
@@ -60,11 +60,13 @@ This project includes a GitHub Actions workflow that runs on push to the main br
 
 ### Starting the application
 
+Start both the backend API and the frontend UI with Docker Compose:
+
 ```bash
 docker-compose up -d
 ```
 
-The API will be available at http://localhost:8000
+The API will be available at http://localhost:8000 and the UI at http://localhost:3000.
 
 ### API Documentation
 
@@ -127,3 +129,34 @@ curl -X 'DELETE' \
   'http://localhost:8000/tasks/1' \
   -H 'accept: application/json'
 ```
+
+## Frontend UI
+
+This repository also provides a simple Next.js application located in the `frontend` directory. The UI consumes the same API and lets you create, complete and delete tasks through a browser.
+
+### Running the UI
+
+During development you can run the UI locally:
+1. Install dependencies (requires internet access):
+   ```bash
+   cd frontend
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+   The app will be available at `http://localhost:3000`.
+
+When using Docker Compose the UI will be served from the container at the same address.
+
+### Testing the UI
+
+- Unit tests:
+  ```bash
+  npm test
+  ```
+- End-to-end tests with Playwright:
+  ```bash
+  npm run test:e2e
+  ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,28 @@
+version: '3.9'
 services:
-  api:
+  backend:
     build:
       context: .
       dockerfile: Dockerfile
-    ports:
-      - "8000:8000"
     volumes:
-      - ./:/app
-      # Bind mount to persist data on local machine
-      - ./data:/app/data
+      - task_data:/app/data
     environment:
       - PYTHONPATH=/app
+    ports:
+      - "8000:8000"
     restart: unless-stopped
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    environment:
+      - NEXT_PUBLIC_API_URL=http://backend:8000
+    ports:
+      - "3000:3000"
+    depends_on:
+      - backend
+    restart: unless-stopped
+
+volumes:
+  task_data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install
+COPY . .
+RUN npm run build
+ENV PORT=3000
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/frontend/__tests__/index.test.tsx
+++ b/frontend/__tests__/index.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import Home from '../pages/index';
+
+describe('Home page', () => {
+  it('renders header', () => {
+    render(<Home />);
+    expect(screen.getByText('Task Manager')).toBeInTheDocument();
+  });
+});

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+};

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+declare namespace NodeJS {
+  interface ProcessEnv {
+    NEXT_PUBLIC_API_URL?: string;
+  }
+}

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,5 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "task-manager-ui",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "test": "jest",
+    "test:e2e": "playwright test"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^14.1.0",
+    "@testing-library/jest-dom": "^6.1.0",
+    "jest": "^29.6.1",
+    "ts-jest": "^29.1.0",
+    "typescript": "^5.3.2",
+    "playwright": "^1.42.1"
+  }
+}

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,0 +1,6 @@
+import type { AppProps } from 'next/app';
+import '../styles/globals.css';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react';
+
+interface Task {
+  id: number;
+  title: string;
+  description?: string;
+  completed: boolean;
+}
+
+export default function Home() {
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
+  useEffect(() => {
+    fetch(`${apiUrl}/tasks/`)
+      .then(res => res.json())
+      .then(setTasks)
+      .catch(console.error);
+  }, [apiUrl]);
+
+  const createTask = async () => {
+    const resp = await fetch(`${apiUrl}/tasks/`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title, description })
+    });
+    if (resp.ok) {
+      const task = await resp.json();
+      setTasks(prev => [...prev, task]);
+      setTitle('');
+      setDescription('');
+    }
+  };
+
+  const completeTask = async (task: Task) => {
+    const resp = await fetch(`${apiUrl}/tasks/${task.id}/complete`, { method: 'PUT' });
+    if (resp.ok) {
+      const updated = await resp.json();
+      setTasks(prev => prev.map(t => (t.id === task.id ? updated : t)));
+    }
+  };
+
+  const deleteTask = async (task: Task) => {
+    const resp = await fetch(`${apiUrl}/tasks/${task.id}`, { method: 'DELETE' });
+    if (resp.ok) {
+      setTasks(prev => prev.filter(t => t.id !== task.id));
+    }
+  };
+
+  return (
+    <div>
+      <h1>Task Manager</h1>
+      <div>
+        <input
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+          placeholder="Title"
+        />
+        <input
+          value={description}
+          onChange={e => setDescription(e.target.value)}
+          placeholder="Description"
+        />
+        <button onClick={createTask}>Add Task</button>
+      </div>
+      <ul>
+        {tasks.map(task => (
+          <li key={task.id} data-testid="task-item">
+            <span style={{ textDecoration: task.completed ? 'line-through' : 'none' }}>
+              {task.title}
+            </span>
+            <button onClick={() => completeTask(task)}>Complete</button>
+            <button onClick={() => deleteTask(task)}>Delete</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  webServer: {
+    command: 'npm run dev',
+    port: 3000,
+    timeout: 120 * 1000,
+    reuseExistingServer: !process.env.CI,
+  },
+  testDir: './tests',
+});

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1,0 +1,4 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 20px;
+}

--- a/frontend/tests/tasks.spec.ts
+++ b/frontend/tests/tasks.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+const baseURL = 'http://localhost:3000';
+
+test('homepage loads', async ({ page }) => {
+  await page.goto(baseURL);
+  await expect(page.locator('h1')).toHaveText('Task Manager');
+});

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add Dockerfile to build Next.js frontend
- clean up backend Dockerfile
- update docker-compose for separate backend and frontend services
- document Docker Compose usage for both services
- ignore frontend build artifacts

## Testing
- `black --check .`
- `isort --check-only .`
- `flake8 .` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*
- `npm test` *(fails: jest not found)*
- `npm run test:e2e` *(fails: playwright not found)*